### PR TITLE
Solving skewing bug on jQuery's plugin (picEdit)

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -619,6 +619,7 @@
 			ctx.rotate(rads);
 			ctx.drawImage(this._image, -this._image.width / 2, -this._image.height / 2);
 			this._image.src = canvas.toDataURL("image/png");
+			this._resizeViewport();
 			this._paintCanvas();
 			this.options.imageUpdated(this._image);
 		},


### PR DESCRIPTION
Merging this pull to my fork:
  - Problem was reported here: https://github.com/andyvr/picEdit/issues/61